### PR TITLE
Preserve original URL across login

### DIFF
--- a/actions/check-server-session.ts
+++ b/actions/check-server-session.ts
@@ -2,11 +2,18 @@
 
 import { auth } from "@/auth"
 import { redirect } from "next/navigation"
+import { cookies } from "next/headers"
 
-export const checkServerSession = async () =>{
+export const checkServerSession = async (path: string = "/") => {
     const session = await auth()
 
     if(!session){
+        const cookieStore = cookies()
+        cookieStore.set("postLoginRedirect", path, {
+            httpOnly: true,
+            sameSite: "lax",
+            secure: process.env.NODE_ENV === "production",
+        })
         redirect("/auth/login")
     }
 }

--- a/actions/login.ts
+++ b/actions/login.ts
@@ -4,6 +4,7 @@ import * as z from "zod";
 import { LoginSchema } from "@/schemas";
 import { signIn } from "@/auth";
 import { AuthError } from "next-auth";
+import { cookies } from "next/headers";
 import {
   generateVerificationToken,
   generateTwoFactorToken,
@@ -87,10 +88,16 @@ export const login = async (
   }
 
   try {
+    const cookieStore = cookies();
+    const cookieRedirect = cookieStore.get("postLoginRedirect")?.value;
+    if (cookieRedirect) {
+      cookieStore.delete("postLoginRedirect");
+    }
+
     await signIn("credentials", {
       email,
       password,
-      redirectTo: callbackUrl || `/?id=${existingUser.id}`,
+      redirectTo: callbackUrl || cookieRedirect || `/?id=${existingUser.id}`,
     });
   } catch (e) {
     if (e instanceof AuthError) {

--- a/app/(protected)/admin/products/add-product/page.tsx
+++ b/app/(protected)/admin/products/add-product/page.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from "react";
 import AddProductForm from "./_components/AddProductForm";
 
 const addProductPage = async () => {
-  await checkServerSession();
+  await checkServerSession("/admin/products/add-product");
 
   return (
     <div className="relative flex justify-center items-center min-h-screen">

--- a/app/(protected)/admin/products/product-details/page.tsx
+++ b/app/(protected)/admin/products/product-details/page.tsx
@@ -80,7 +80,9 @@ const ProductDetailsPage = () => {
 
   useEffect(() => {
     const fetchProduct = async () => {
-      await checkServerSession();
+      await checkServerSession(
+        window.location.pathname + window.location.search,
+      );
       if (productId) {
         const fetchedProduct = await getProductById(productId);
         setProduct(fetchedProduct);

--- a/middleware.tsx
+++ b/middleware.tsx
@@ -2,19 +2,25 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "./auth";
 
 export default async function middleware(request: NextRequest) {
-  const isLoggedIn = async () => {
-    const session = await auth();
-    if (!session) {
-      return false;
-    }
-    return true;
-  };
-
-  if (await isLoggedIn()) {
+  const session = await auth();
+  if (session) {
     return NextResponse.next();
   }
 
-  return NextResponse.redirect(new URL("/auth/login", request.url));
+  const response = NextResponse.redirect(
+    new URL("/auth/login", request.url),
+  );
+  response.cookies.set(
+    "postLoginRedirect",
+    request.nextUrl.pathname + request.nextUrl.search,
+    {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+    },
+  );
+
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- store post-login redirect path in a secure cookie from middleware or server actions
- read and clear that cookie when signing in
- update protected admin pages to pass their URL to the session checker

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686163424cf08331ac6c60647046a280